### PR TITLE
#1636 Expose all project entity counts in entityCounts

### DIFF
--- a/ontrack-kdsl/ontrack.graphql
+++ b/ontrack-kdsl/ontrack.graphql
@@ -1867,8 +1867,20 @@ type EnableSubscriptionPayload implements Payload {
 
 "Representation of the entity counts"
 type EntityCounts {
+  "Number of branches"
+  branches: Int!
+  "Number of builds"
+  builds: Int!
   "Number of projects"
   projects: Int!
+  "Number of promotion levels"
+  promotionLevels: Int!
+  "Number of promotion runs"
+  promotionRuns: Int!
+  "Number of validation runs"
+  validationRuns: Int!
+  "Number of validation stamps"
+  validationStamps: Int!
 }
 
 "Extra information component about an entity"

--- a/ontrack-ui-graphql/src/main/java/net/nemerosa/ontrack/graphql/schema/GQLRootQueryEntityCounts.kt
+++ b/ontrack-ui-graphql/src/main/java/net/nemerosa/ontrack/graphql/schema/GQLRootQueryEntityCounts.kt
@@ -38,13 +38,25 @@ class GQLTypeEntityCounts(
         GraphQLObjectType.newObject()
             .name(typeName)
             .description("Representation of the entity counts")
-            .field {
-                it.name("projects")
-                    .description("Number of projects")
-                    .type(GraphQLNonNull(GraphQLInt))
-                    .dataFetcher { statsService.projectCount }
-            }
+            .countField("projects", "Number of projects") { statsService.projectCount }
+            .countField("branches", "Number of branches") { statsService.branchCount }
+            .countField("promotionLevels", "Number of promotion levels") { statsService.promotionLevelCount }
+            .countField("validationStamps", "Number of validation stamps") { statsService.validationStampCount }
+            .countField("builds", "Number of builds") { statsService.buildCount }
+            .countField("promotionRuns", "Number of promotion runs") { statsService.promotionRunCount }
+            .countField("validationRuns", "Number of validation runs") { statsService.validationRunCount }
             .build()
+
+    private fun GraphQLObjectType.Builder.countField(
+        name: String,
+        description: String,
+        count: () -> Int,
+    ) = field {
+        it.name(name)
+            .description(description)
+            .type(GraphQLNonNull(GraphQLInt))
+            .dataFetcher { count() }
+    }
 
 }
 

--- a/ontrack-ui-graphql/src/test/java/net/nemerosa/ontrack/graphql/EntityCountsGraphQLIT.kt
+++ b/ontrack-ui-graphql/src/test/java/net/nemerosa/ontrack/graphql/EntityCountsGraphQLIT.kt
@@ -22,4 +22,47 @@ class EntityCountsGraphQLIT: AbstractQLKTITSupport() {
         }
     }
 
+    @Test
+    fun `Counts for all project entities`() {
+        asAdmin {
+            project {
+                branch {
+                    val pl = promotionLevel()
+                    val vs = validationStamp()
+                    build {
+                        promote(pl)
+                        validate(vs)
+                    }
+                }
+            }
+            run("""{
+                entityCounts {
+                    projects
+                    branches
+                    promotionLevels
+                    validationStamps
+                    builds
+                    promotionRuns
+                    validationRuns
+                }
+            }""").let { data ->
+                val counts = data.path("entityCounts")
+                listOf(
+                    "projects",
+                    "branches",
+                    "promotionLevels",
+                    "validationStamps",
+                    "builds",
+                    "promotionRuns",
+                    "validationRuns",
+                ).forEach { field ->
+                    assertTrue(
+                        counts.path(field).asInt() > 0,
+                        "At least one entity counted for $field"
+                    )
+                }
+            }
+        }
+    }
+
 }

--- a/ontrack-web-core/ontrack.graphql
+++ b/ontrack-web-core/ontrack.graphql
@@ -1876,8 +1876,20 @@ type EnableSubscriptionPayload implements Payload {
 
 "Representation of the entity counts"
 type EntityCounts {
+  "Number of branches"
+  branches: Int!
+  "Number of builds"
+  builds: Int!
   "Number of projects"
   projects: Int!
+  "Number of promotion levels"
+  promotionLevels: Int!
+  "Number of promotion runs"
+  promotionRuns: Int!
+  "Number of validation runs"
+  validationRuns: Int!
+  "Number of validation stamps"
+  validationStamps: Int!
 }
 
 "Extra information component about an entity"

--- a/ontrack-web-tests/ontrack.graphql
+++ b/ontrack-web-tests/ontrack.graphql
@@ -1876,8 +1876,20 @@ type EnableSubscriptionPayload implements Payload {
 
 "Representation of the entity counts"
 type EntityCounts {
+  "Number of branches"
+  branches: Int!
+  "Number of builds"
+  builds: Int!
   "Number of projects"
   projects: Int!
+  "Number of promotion levels"
+  promotionLevels: Int!
+  "Number of promotion runs"
+  promotionRuns: Int!
+  "Number of validation runs"
+  validationRuns: Int!
+  "Number of validation stamps"
+  validationStamps: Int!
 }
 
 "Extra information component about an entity"


### PR DESCRIPTION
Closes #1636

## Problem

The `entityCounts` GraphQL root query only returned `projects`, even though `StatsService` (and `StatsJdbcRepository` behind it) already exposed counts for every project entity. Only the GraphQL type was missing the fields — no service or repository change was needed.

## Change

`GQLTypeEntityCounts` now exposes one field per `ProjectEntityType`:

| Field | Source |
|---|---|
| `projects` (existing) | `statsService.projectCount` |
| `branches` | `statsService.branchCount` |
| `promotionLevels` | `statsService.promotionLevelCount` |
| `validationStamps` | `statsService.validationStampCount` |
| `builds` | `statsService.buildCount` |
| `promotionRuns` | `statsService.promotionRunCount` |
| `validationRuns` | `statsService.validationRunCount` |

The fields are declared through a small private `countField` builder extension so each stays a single line.

Scope is the seven `ProjectEntityType` values, matching the issue's "branches, build and other project entities". `StatsService` also offers `validationRunStatusCount`, `propertyCount` and `eventCount` — those are not project entities, so they were left out; they are trivial to add if wanted.

The generated `ontrack.graphql` snapshots (`ontrack-web-core`, `ontrack-web-tests`, `ontrack-kdsl`) were updated with the new fields, in the generator's alphabetical order with descriptions. These were hand-edited to match what a regeneration emits, since no running backend was available.

## Tests

New `Counts for all project entities` in `EntityCountsGraphQLIT` builds a project → branch → promotion level + validation stamp → build → promotion run + validation run, then asserts every count field returns > 0. The existing `Project counts` test is unchanged.

- `./gradlew :ontrack-ui-graphql:compileKotlin` / `:compileTestKotlin` — pass
- `./gradlew :ontrack-ui-graphql:test` — pass
- `./gradlew integrationTest` — **not run**: Docker was unavailable in the environment, so `EntityCountsGraphQLIT` is unverified and needs a run before merge

## Note

`CLAUDE.md` states work lands by merging into `main` rather than via pull request. This PR was opened at explicit request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HvHyqVdRpcxw9DkMwQ6bzj

---
_Generated by [Claude Code](https://claude.ai/code/session_01HvHyqVdRpcxw9DkMwQ6bzj)_